### PR TITLE
fix: Inherit_Container_Type_and_Name_from_Cascading_Stylesheet

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -766,6 +766,11 @@ class ShadowRootController extends NodeController<ShadowRoot> {
   }
 
   connected(): void {
+    window.onload = () => {
+      const styleElement = document.createElement("style");
+      styleElement.textContent = `* { ${CUSTOM_PROPERTY_TYPE}: inherit; ${CUSTOM_PROPERTY_NAME}: inherit; }`;
+      this.node.appendChild(styleElement);
+    }
     this.mo?.observe(this.node, {
       childList: true,
       subtree: true,


### PR DESCRIPTION
Resolves #33

The default container type and name are set at the global document level via a cascading stylesheet. 

Content of the ShadowDom will inherit from the content parent over the global cascading stylesheet due to increased specificity... this is the reason elements in the shadow dom inherit `container-type: inline-size;` from their parents; effectively making them a `container` in the eyes of the polyfill. 

Creating a styleElement that inherits the default values from the global document for each newly added shadowDom elevates the default specificity and resolves the issue.